### PR TITLE
Use NodePort for UI and backend kube containers. That way, only gatew…

### DIFF
--- a/backend/kubefile.yaml
+++ b/backend/kubefile.yaml
@@ -9,7 +9,7 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 8080
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/ui/kubefile.yaml
+++ b/ui/kubefile.yaml
@@ -9,7 +9,7 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 80
-  type: LoadBalancer
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
…ay is using LoadBalancer, and we can easily identify correct URL by looking at LoadBalancers in AWS console